### PR TITLE
Spotifyで取得した画像のサイズ調整

### DIFF
--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -11638,20 +11638,30 @@ form.top-animation {
 }
 
 .search-result-card .debayashi-info .debayashi-img {
-  border: 1px solid blue;
   width: 174px;
   height: 174px;
   margin: 0 auto 26px;
   position: relative;
 }
 
-.search-result-card .debayashi-info .debayashi-img p {
+.search-result-card .debayashi-info .debayashi-img img {
+  width: 100%;
+  height: auto;
+}
+
+.search-result-card .debayashi-info .debayashi-img .alt-desc {
+  border: 1px solid blue;
+  width: 100%;
+  height: 100%;
+}
+
+.search-result-card .debayashi-info .debayashi-img .alt-desc p {
+  opacity: 0.5;
   position: absolute;
   top: 50%;
   left: 50%;
   -webkit-transform: translate(-50%, -50%);
           transform: translate(-50%, -50%);
-  opacity: 0.5;
 }
 
 .search-result-card .debayashi-info p {

--- a/src/resources/sass/_search.scss
+++ b/src/resources/sass/_search.scss
@@ -38,17 +38,25 @@
         word-break: break-all;
       }
       .debayashi-img {
-        border: 1px solid blue;
-        width: 174px;
-        height: 174px;
+          width: 174px;
+          height: 174px;
         margin: 0 auto 26px;
         position: relative;
-        p {
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform : translate(-50%,-50%);
-          opacity: 0.5;
+        img {
+          width: 100%;
+          height: auto;
+        }
+        .alt-desc {
+          border: 1px solid blue;
+          width: 100%;
+          height: 100%;
+          p {
+            opacity: 0.5;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform : translate(-50%,-50%);
+          }
         }
       }
       p {

--- a/src/resources/views/search/index.blade.php
+++ b/src/resources/views/search/index.blade.php
@@ -15,7 +15,9 @@
             @if ($spotifyValue && $spotifyValue['image_url'])
             <img src="{{ $spotifyValue['image_url'] }}" alt="{{ $spotifyValue['name'] }}">
             @else
-            <p>No Image</p>
+              <div class="alt-desc">
+                <p>No Image</p>
+              </div>
             @endif
           </div>
           <p class="debayashi-name">{{ $debayashi->name }}</p>


### PR DESCRIPTION
# 目的
- Spotifyで取得した画像が300×300のため画面デザインにフィットするようサイズ調整

# 関連するissue
- https://github.com/ienokado/debayashi-koreyashi/issues/16

# レビューポイント

# 留意事項

# 残課題

# その他
