### PR TITLE
SNSシェアボタン用コメントの設定

### DIFF
--- a/src/app/Http/Controllers/DebayashiSearchController.php
+++ b/src/app/Http/Controllers/DebayashiSearchController.php
@@ -26,13 +26,46 @@ class DebayashiSearchController extends Controller
         // Apple Music検索
         $appleMusicValue = $this->appleMusicSearch($debayashi);
 
+        // シェアボタン用テキストの取得
+        $shareText = $this->getShareText($debayashi, $spotifyValue, $appleMusicValue);
+
         //検索フォームへ
         return view('search.index', [
             'debayashi' => $debayashi,
             'spotifyValue' => $spotifyValue,
             'appleMusicValue' => $appleMusicValue,
+            'shareText' => $shareText,
             'keyword' => $keyword,
         ]);
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @param Debayashi $debayashi
+     * @param array $spotifyValue
+     * @param array $appleMusic
+     * @return void
+     */
+    private function getShareText($debayashi = null, $spotifyValue = null, $appleMusic = null)
+    {
+        $text = "";
+
+        if ($debayashi) {
+            // 芸人名
+            $comedianName = $debayashi->comedianGroups()->first()->name;
+            // 出囃子名
+            $debayashiName = $debayashi->name;
+            // アーティスト名
+            $artistName = $debayashi->artist_name;
+
+            // コメントの生成
+            $text .= "みんな知ってた？%0a";
+            $text .= "「${comedianName}」の出囃子は・・・「${debayashiName} - ${artistName}」%0a";
+            $text .= "%23". env('APP_NAME');
+        }
+
+        return $text;
     }
 
     /**

--- a/src/app/Http/Controllers/DebayashiSearchController.php
+++ b/src/app/Http/Controllers/DebayashiSearchController.php
@@ -62,7 +62,7 @@ class DebayashiSearchController extends Controller
             // コメントの生成
             $text .= "みんな知ってた？%0a";
             $text .= "「${comedianName}」の出囃子は・・・「${debayashiName} - ${artistName}」%0a";
-            $text .= "%23". env('APP_NAME');
+            $text .= "%23" . env('APP_NAME');
         }
 
         return $text;

--- a/src/config/const.php
+++ b/src/config/const.php
@@ -3,7 +3,7 @@ return [
     'sns_share_url' => [
         'facebook' => env('FACEBOOK_SHARE_URL', 'https://www.facebook.com/sharer/sharer.php?u='). env('APP_URL'),
         'twitter' => env('TWITTER_SHARE_URL', 'http://twitter.com/share?url='). env('APP_URL'),
-        'line' => env('LINE_SHARE_URL', 'https://social-plugins.line.me/lineit/share?url='). env('APP_URL'),
+        'line' => env('LINE_SHARE_URL', 'http://line.me/R/msg/text/?'). env('APP_URL'). '%0a',
     ],
     'cookie_expire' => [
         'disp_count' => 60*60*24*30,

--- a/src/resources/views/search/index.blade.php
+++ b/src/resources/views/search/index.blade.php
@@ -43,13 +43,13 @@
         </div>
         <div class="share-area">
           <span class="share-item">SHARE ON</span>
-          <a class="share-item" href="{{ config('const.sns_share_url.twitter') }}" target="_blank">
+            <a class="share-item" href="{{ config('const.sns_share_url.twitter') }}&text={{ $shareText }}" target="_blank">
             <i class="fab fa-twitter"></i>
           </a>
           <a class="share-item" href="{{ config('const.sns_share_url.facebook') }}" target="_blank">
             <i class="fab fa-facebook-f"></i>
           </a>
-          <a class="share-item" href="{{ config('const.sns_share_url.line') }}" target="_blank">
+          <a class="share-item" href="{{ config('const.sns_share_url.line') }}{{ $shareText }}" target="_blank">
             <i class="fab fa-line"></i>
           </a>
         </div>


### PR DESCRIPTION
# 目的
- SNSシェアボタンの初期コメントを動的に設定

# 関連するissue
- https://github.com/ienokado/debayashi-koreyashi/issues/15

# レビューポイント
シェアボタン用コメント生成処理

# 留意事項
Facebookについてはogpタグでしか初期コメントを設定できないようなので
調整が必要

# 残課題
テスト

# その他
