### PR TITLE
AppleMusic検索結果判定を修正

### DIFF
--- a/src/app/Facades/AppleMusicFacade.php
+++ b/src/app/Facades/AppleMusicFacade.php
@@ -42,11 +42,14 @@ class AppleMusicFacade extends Facade
      */
     public function search($query, $type = 'songs', $limit = 1)
     {
-        $api = new AppleMusicAPI($this->client);
+        $data = null;
 
         try {
+            $api = new AppleMusicAPI($this->client);
             $result = $api->searchCatalog(env('APPLE_COUNTRY_CODE'), $query . '&limit=' . $limit, $type);
-            $data = $result->results->songs->data;
+            if (property_exists($result->results, 'songs')) {
+                $data = $result->results->songs->data;
+            }
         } catch (\Exception $e) {
             throw $e;
         }


### PR DESCRIPTION
# 目的
- AppleMusicAPIでの検索処理で特定の芸人名で調べるとエラーになっていた（結果のレスポンスがちょっと変）
  - コウテイ
  - 金属バット
# 関連するissue
なし

# レビューポイント

# 留意事項

# 残課題

# その他
