### PR TITLE
管理画面のルーティングテストを追加

### DIFF
--- a/src/app/Http/Controllers/Admin/System/LogController.php
+++ b/src/app/Http/Controllers/Admin/System/LogController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Admin;
+namespace App\Http\Controllers\Admin\System;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;

--- a/src/database/factories/ComedianGroupFactory.php
+++ b/src/database/factories/ComedianGroupFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\ComedianGroup;
+use Faker\Generator as Faker;
+
+$factory->define(ComedianGroup::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'description' => $faker->sentence,
+        'dissolve_flg' => 0,
+        'active' => 1,
+    ];
+});

--- a/src/database/factories/DebayashiFactory.php
+++ b/src/database/factories/DebayashiFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\Debayashi;
+use Faker\Generator as Faker;
+
+$factory->define(Debayashi::class, function (Faker $faker) {
+    return [
+        'name' => $faker->title,
+        'artist_name' => $faker->name,
+        'active' => 1,
+    ];
+});

--- a/src/routes/admin.php
+++ b/src/routes/admin.php
@@ -16,9 +16,6 @@ if (App::environment('production')) {
 Route::group(['middleware' => 'guest:admin'], function() {
     Route::get('/login', 'Auth\LoginController@showLoginForm')->name('login.form');
     Route::post('/login', 'Auth\LoginController@login')->name('login');
-
-    Route::get('/404', function () { return view('admin.404'); });
-    Route::get('/500', function () { return view('admin.500'); });
 });
 
 Route::group(['middleware' => 'auth:admin'], function(){
@@ -36,5 +33,5 @@ Route::group(['middleware' => 'auth:admin'], function(){
     Route::get('/comedian_group/{id}/edit', 'ComedianGroupController@edit')->name('comedian_group.edit');
     Route::post('/comedian_group/store', 'ComedianGroupController@store')->name('comedian_group.store');
 
-    Route::get('/system/log', 'LogController@index')->name('system.log');
+    Route::get('/system/log', 'System\LogController@index')->name('system.log');
 });

--- a/src/tests/Feature/Http/Controllers/Admin/Auth/LoginControllerTest.php
+++ b/src/tests/Feature/Http/Controllers/Admin/Auth/LoginControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Admin\Auth;
+
+use App\Models\AdminUser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class LoginControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // テスト管理者ユーザ作成
+        $this->adminUser = factory(AdminUser::class)->create();
+    }
+
+    /**
+     * 管理画面ログインフォーム表示のルーティング.
+     *
+     * @return void
+     */
+    public function testLoginFormRouting()
+    {
+        $response = $this->get(route('admin.login.form'));
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * ログイン処理のルーティング.
+     *
+     * @return void
+     */
+    public function testLoginRouting()
+    {
+        $response = $this->post(route('admin.login'), [
+            '_token' => csrf_token(),
+            'email' => $this->adminUser->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect(route('admin.top'));
+        // 認証された管理ユーザー判定
+        $this->assertAuthenticatedAs($this->adminUser, 'admin');
+    }
+
+    /**
+     * ログアウト処理のルーティング.
+     *
+     * @return void
+     */
+    public function testLogoutRouting()
+    {
+        // actingAsヘルパで現在認証済みのユーザーを指定する
+        $response = $this->actingAs($this->adminUser, 'admin')->get(route('admin.logout'));
+
+        $response->assertRedirect(route('admin.top'));
+
+        $this->assertGuest('admin');
+    }
+}

--- a/src/tests/Feature/Http/Controllers/Admin/ComedianGroupControllerTest.php
+++ b/src/tests/Feature/Http/Controllers/Admin/ComedianGroupControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Admin;
+
+use App\Models\AdminUser;
+use App\Models\ComedianGroup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ComedianGroupControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // テスト管理者ユーザ作成
+        $this->adminUser = factory(AdminUser::class)->create();
+    }
+
+    /**
+     * 芸人一覧表示のルーティング.
+     *
+     * @return void
+     */
+    public function testComedianGroupRouting()
+    {
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->get(route('admin.comedian_group'));
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 芸人新規登録画面表示のルーティング.
+     *
+     * @return void
+     */
+    public function testComedianGroupNewRouting()
+    {
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->get(route('admin.comedian_group.new'));
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 芸人編集画面表示のルーティング.
+     *
+     * @return void
+     */
+    public function testComedianGroupEditRouting()
+    {
+        // テスト芸人データの作成
+        $comedianGroup = factory(ComedianGroup::class)->create();
+
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->get(route('admin.comedian_group.edit', ['id' => $comedianGroup->id]));
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 芸人登録処理のルーティング.
+     *
+     * @return void
+     */
+    public function testComedianGroupStoreRouting()
+    {
+        // テスト芸人データの作成
+        $comedianGroup = factory(ComedianGroup::class)->create();
+
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->post(route('admin.comedian_group.store'), [
+                '_token' => csrf_token(),
+                'id' => $comedianGroup->id,
+                'name' => 'テスト',
+            ]);
+
+        $response->assertRedirect(route('admin.comedian_group.edit', ['id' => $comedianGroup->id]));
+    }
+}

--- a/src/tests/Feature/Http/Controllers/Admin/DebayashiControllerTest.php
+++ b/src/tests/Feature/Http/Controllers/Admin/DebayashiControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Admin;
+
+use App\Models\AdminUser;
+use App\Models\Debayashi;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DebayashiControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // テスト管理者ユーザ作成
+        $this->adminUser = factory(AdminUser::class)->create();
+    }
+
+    /**
+     * 出囃子一覧表示のルーティング.
+     *
+     * @return void
+     */
+    public function testDebayashiRouting()
+    {
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->get(route('admin.debayashi'));
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 出囃子新規登録画面表示のルーティング.
+     *
+     * @return void
+     */
+    public function testDebayashiNewRouting()
+    {
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->get(route('admin.debayashi.new'));
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 出囃子編集画面表示のルーティング.
+     *
+     * @return void
+     */
+    public function testDebayashiEditRouting()
+    {
+        // テスト出囃子データの作成
+        $debayashi = factory(Debayashi::class)->create();
+
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->get(route('admin.debayashi.edit', ['id' => $debayashi->id]));
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 出囃子登録処理のルーティング.
+     *
+     * @return void
+     */
+    public function testDebayashiStoreRouting()
+    {
+        // テスト出囃子データの作成
+        $debayashi = factory(Debayashi::class)->create();
+
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->post(route('admin.debayashi.store'), [
+                '_token' => csrf_token(),
+                'id' => $debayashi->id,
+                'name' => 'テスト出囃子',
+                'artist_name' => 'テストアーティスト',
+            ]);
+
+        $response->assertRedirect(route('admin.debayashi.edit', ['id' => $debayashi->id]));
+    }
+}

--- a/src/tests/Feature/Http/Controllers/Admin/System/LogControllerTest.php
+++ b/src/tests/Feature/Http/Controllers/Admin/System/LogControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Admin\System;
+
+use App\Models\AdminUser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class LogControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // テスト管理者ユーザ作成
+        $this->adminUser = factory(AdminUser::class)->create();
+    }
+
+    /**
+     * リクエストログ一覧表示のルーティング.
+     *
+     * @return void
+     */
+    public function testRouting()
+    {
+        $response = $this
+            ->actingAs($this->adminUser, 'admin')
+            ->withSession(['user_id' => $this->adminUser])
+            ->get(route('admin.system.log'));
+
+        $response->assertStatus(200);
+    }
+}

--- a/src/tests/Feature/Http/Controllers/Admin/TopControllerTest.php
+++ b/src/tests/Feature/Http/Controllers/Admin/TopControllerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class TopControllerTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
# 目的
- 今まで作っている処理のテストコードを追加することでcoverageを良くしたい

# 関連するissue
- https://github.com/ienokado/debayashi-koreyashi/issues/29

# レビューポイント

# 留意事項

# 残課題
モデルのテスト、サービスのテストなど
# その他
