### PR TITLE
検索履歴の追加/取得処理

### DIFF
--- a/src/app/Http/Controllers/Controller.php
+++ b/src/app/Http/Controllers/Controller.php
@@ -26,8 +26,12 @@ class Controller extends BaseController
      * @param AppleMusicService $appleMusicService
      * @param SpotifyService $spotifyService
      */
-    public function __construct(Request $request, Agent $agent, AppleMusicService $appleMusicService, SpotifyService $spotifyService)
-    {
+    public function __construct(
+        Request $request,
+        Agent $agent,
+        AppleMusicService $appleMusicService,
+        SpotifyService $spotifyService
+    ) {
         $this->appleMusicService = $appleMusicService;
         $this->spotifyService = $spotifyService;
         $this->cookieName = $this->getCookieName();

--- a/src/app/Http/Controllers/Debayashi/HistoryController.php
+++ b/src/app/Http/Controllers/Debayashi/HistoryController.php
@@ -3,18 +3,38 @@
 namespace App\Http\Controllers\Debayashi;
 
 use App\Http\Controllers\Controller;
+use App\Models\Debayashi;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
 
 class HistoryController extends Controller
 {
     /**
-     * 個々の検索履歴表示
+     * 個々の検索履歴表示.
      *
      * @param Request $request
      * @return void
      */
     public function index(Request $request)
     {
-        return view('debayashi.history');
+        $debayashis = $this->getSearchHistories();
+
+        return view('debayashi.history',[
+            'debayashis' => $debayashis,
+        ]);
+    }
+
+    /**
+     * 検索履歴を返す.
+     *
+     * @return Debayshi
+     */
+    private function getSearchHistories()
+    {
+        $_cookieName = 'Search_' . $this->cookieName;
+
+        $ids = explode(',', Cookie::get($_cookieName));
+
+        return Debayashi::find($ids);
     }
 }

--- a/src/app/Http/Controllers/Debayashi/HistoryController.php
+++ b/src/app/Http/Controllers/Debayashi/HistoryController.php
@@ -19,7 +19,7 @@ class HistoryController extends Controller
     {
         $debayashis = $this->getSearchHistories();
 
-        return view('debayashi.history',[
+        return view('debayashi.history', [
             'debayashis' => $debayashis,
         ]);
     }

--- a/src/app/Http/Controllers/Debayashi/SearchController.php
+++ b/src/app/Http/Controllers/Debayashi/SearchController.php
@@ -58,7 +58,7 @@ class SearchController extends Controller
         if (!is_null($ids) && strpos($ids, (string) $debayashi->id) === false) {
             $ids .= ',' . $debayashi->id;
         // 初回のみ
-        } else if (is_null($ids)) {
+        } elseif (is_null($ids)) {
             $ids .= (string) $debayashi->id;
         }
 

--- a/src/app/Http/Controllers/Debayashi/SearchController.php
+++ b/src/app/Http/Controllers/Debayashi/SearchController.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Controllers\Debayashi;
 
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Models\Debayashi;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
 
 class SearchController extends Controller
 {
@@ -22,8 +23,9 @@ class SearchController extends Controller
         $keyword = $request->input('search_keyword');
 
         // もしキーワードが入力されている場合
-        if (!empty($keyword)) {
+        if ($keyword) {
             $debayashi = Debayashi::getByKeyword($keyword);
+            $this->setKeyword($debayashi);
         }
 
         // Spotify検索
@@ -39,5 +41,27 @@ class SearchController extends Controller
             'shareText' => $shareText,
             'keyword' => $keyword,
         ]);
+    }
+
+    private function setKeyword(Debayashi $debayashi)
+    {
+        // 出囃子
+        if (is_null($debayashi)) {
+            return;
+        }
+
+        $_cookieName = $this->cookieName . '_History';
+
+        $ids = Cookie::get($_cookieName);
+
+        // 初回以降かつ検索されていない出囃子の場合
+        if (!is_null($ids) && strpos($ids, (string) $debayashi->id) === false) {
+            $ids .= ',' . $debayashi->id;
+        // 初回のみ
+        } else if (is_null($ids)) {
+            $ids .= (string) $debayashi->id;
+        }
+
+        Cookie::queue(Cookie::make($_cookieName, $ids));
     }
 }

--- a/src/app/Http/Controllers/TopController.php
+++ b/src/app/Http/Controllers/TopController.php
@@ -15,7 +15,7 @@ class TopController extends Controller
     public function __invoke(Request $request)
     {
         return view('top', [
-            'cookieName' => $this->getCookieName(),
+            'cookieName' => $this->cookieName . '_DispCount',
         ]);
     }
 }

--- a/src/app/Http/Middleware/EncryptCookies.php
+++ b/src/app/Http/Middleware/EncryptCookies.php
@@ -13,5 +13,6 @@ class EncryptCookies extends Middleware
      */
     protected $except = [
         //
+        'Search_History'
     ];
 }


### PR DESCRIPTION
# 目的
- 検索履歴機能の追加

# 関連するissue
- https://github.com/ienokado/debayashi-koreyashi/issues/105

# レビューポイント
検索履歴のクッキーでの生成
検索履歴のクッキー情報を取得する

# 留意事項
出囃子IDをクッキーに保存しているのでセキュリティ的にはまずいか。。。

# 残課題
出囃子IDを本来はRedisとかキー＆バリューの保存がしたい
キーはユニークユーザーIDでバリューはIDのハッシュ
セッションでなくRedisなら外からみられる心配がさほどないかな。。

# その他
