### PR TITLE
出囃子検索ログを1日1回DB登録するバッチ処理

### DIFF
--- a/src/app/Console/Commands/SearchHistoryRegist.php
+++ b/src/app/Console/Commands/SearchHistoryRegist.php
@@ -69,7 +69,7 @@ class SearchHistoryRegist extends Command
                     ]);
                     $count++;
                 } catch (\Exception $e) {
-                    \Log::channel('slack')->info('keyword: ' . $value['request'] . '/ip: ' . $value['ip'], $e);
+                    \Log::channel('slack')->error('keyword: ' . $value['request'] . '/ip: ' . $value['ip'], $e);
                 }
             }
         }

--- a/src/app/Console/Commands/SearchHistoryRegist.php
+++ b/src/app/Console/Commands/SearchHistoryRegist.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ComedianGroup;
+use App\Models\SearchHistory;
+use Illuminate\Console\Command;
+
+class SearchHistoryRegist extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:search_history_regist {date?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'キーワード検索でヒットした芸人の出囃子をDBに登録する';
+
+    /**
+     * date
+     *
+     * @var string
+     */
+    protected $date;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // 指定された日付 or 昨日分のログを取得
+        $this->date = $this->argument('date') ? $this->argument('date') : date('Y-m-d', strtotime('-1 day'));
+        // 件数カウント
+        $count = 0;
+
+        $data = $this->parseLogFile();
+        // 検索ログカウント
+        $logCount = count($data);
+
+        foreach ($data as $value) {
+            $comedianGroup = ComedianGroup::where('name', $value['request'])->first();
+            if ($comedianGroup) {
+                try {
+                    SearchHistory::create([
+                        'keyword' => $value['request'],
+                        'debayashi_id' => $comedianGroup->debayashi ? $comedianGroup->debayashi->id : null,
+                        'comedian_group_id' => $comedianGroup->id,
+                        'user_agent' => $value['user-agent'],
+                        'ip_address' => $value['ip'],
+                        'searched_at' => $value['searched_at'],
+                    ]);
+                    $count++;
+                } catch (\Exception $e) {
+                    \Log::channel('slack')->info('keyword: ' . $value['request'] . '/ip: ' . $value['ip'], $e);
+                }
+            }
+        }
+
+        // ロギング
+        \Log::channel('slack')->info("履歴日: " . $this->date . "/検索履歴件数: ${logCount}件/履歴登録件数: ${count}件");
+    }
+
+    /**
+     * parse log file
+     *
+     * @return array
+     */
+    private function parseLogFile()
+    {
+        $log = [];
+
+        $fileName = "request-" . $this->date . ".log";
+        $logFile = storage_path("logs/${fileName}");
+
+        if (file_exists($logFile)) {
+            foreach (array_reverse(file($logFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)) as $line) {
+                if (preg_match_all('/\[.*?\]|{.*?}/', $line, $matches)) {
+                    $jsonData = json_decode($matches[0][1], true);
+                    $jsonData['searched_at'] = str_replace(['[', ']'], '', $matches[0][0]);
+                    $log[] = $jsonData;
+                }
+            }
+        }
+
+        return $log;
+    }
+}

--- a/src/app/Http/Controllers/Debayashi/RankingController.php
+++ b/src/app/Http/Controllers/Debayashi/RankingController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Debayashi;
 
 use App\Http\Controllers\Controller;
+use App\Models\SearchHistory;
+use App\Models\ComedianGroup;
 use Illuminate\Http\Request;
 
 class RankingController extends Controller
@@ -15,6 +17,20 @@ class RankingController extends Controller
      */
     public function index(Request $request)
     {
-        return view('debayashi.ranking');
+        $comedianGroups = [];
+
+        $rankingData = SearchHistory::getRanking();
+        foreach ($rankingData as $data) {
+            try {
+                $comedianGroup = ComedianGroup::find($data->comedian_group_id);
+                $comedianGroups[] = $comedianGroup;
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+
+        return view('debayashi.ranking', [
+            'comedianGroups' => $comedianGroups,
+        ]);
     }
 }

--- a/src/app/Models/Debayashi.php
+++ b/src/app/Models/Debayashi.php
@@ -23,8 +23,8 @@ class Debayashi extends Model
 
     public static function getByKeyword(string $keyword = null)
     {
-        return Debayashi::whereHas('comedianGroups', function ($query) use ($keyword) {
+        return self::whereHas('comedianGroups', function ($query) use ($keyword) {
             $query->where('name', "${keyword}");
-        })->get()->first();
+        })->first();
     }
 }

--- a/src/app/Models/Debayashi.php
+++ b/src/app/Models/Debayashi.php
@@ -6,13 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class Debayashi extends Model
 {
-    /**
-     * モデルと関連しているテーブル
-     *
-     * @var string
-     */
-    protected $table = 'debayashis';
-
     public function comedianGroups()
     {
         return $this->hasMany(ComedianGroup::class);

--- a/src/app/Models/SearchHistory.php
+++ b/src/app/Models/SearchHistory.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class SearchHistory extends Model
 {
-    //
+    protected $fillable = ['keyword', 'debayashi_id', 'comedian_group_id', 'user_agent', 'ip_address', 'searched_at'];
 }

--- a/src/app/Models/SearchHistory.php
+++ b/src/app/Models/SearchHistory.php
@@ -7,4 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class SearchHistory extends Model
 {
     protected $fillable = ['keyword', 'debayashi_id', 'comedian_group_id', 'user_agent', 'ip_address', 'searched_at'];
+
+    public static function getRanking()
+    {
+        // ランキング表示は10件まで（定数で指定）
+        return self::select(\DB::raw('count(*) as count, comedian_group_id'))
+            ->groupBy('comedian_group_id')
+            ->orderBy('count')
+            ->limit(config('const.ranking.count'))
+            ->get();
+    }
 }

--- a/src/config/const.php
+++ b/src/config/const.php
@@ -15,4 +15,7 @@ return [
             'production',
         ],
     ],
+    'ranking' => [
+        'count' => 10,
+    ]
 ];

--- a/src/config/logging.php
+++ b/src/config/logging.php
@@ -71,9 +71,9 @@ return [
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),
-            'username' => 'Laravel Log',
-            'emoji' => ':boom:',
-            'level' => 'critical',
+            'username' => 'Debayashi Koreyashi Log',
+            'emoji' => ':debayashi:',
+            'level' => 'info',
         ],
 
         'papertrail' => [

--- a/src/database/migrations/2020_05_03_133314_change_search_history.php
+++ b/src/database/migrations/2020_05_03_133314_change_search_history.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeSearchHistory extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('search_histories', function (Blueprint $table) {
+            $table->dropColumn('comedian_group_name');
+            $table->dropColumn('debayashi_name');
+            $table->dropColumn('artist_name');
+            $table->dropColumn('User-Agent');
+            $table->text('user_agent')->nullable()->comment('検索したユーザーの端末情報')->after('debayashi_id');
+            $table->text('ip_address')->nullable()->comment('検索したユーザーのip')->after('user_agent');
+            $table->dateTime('searched_at')->nullable()->comment('ユーザーが検索した日時')->after('ip_address');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('search_histories', function (Blueprint $table) {
+            $table->text('comedian_group_name')->nullable()->comment('検索失敗時のユーザー登録希望のコンビ名')->after('comedian_group_id');
+            $table->text('debayashi_name')->nullable()->comment('芸人登録がある場合のユーザーが登録希望の出囃子名')->after('debayashi_id');
+            $table->text('artist_name')->nullable()->comment('芸人登録がある場合のユーザーが登録希望の出囃子のアーティスト名')->after('artist_name');
+            $table->dropColumn('user_agent');
+            $table->dropColumn('ip_address');
+            $table->dropColumn('searched_at');
+        });
+    }
+}


### PR DESCRIPTION
# 目的
- 検索ランキングのための検索履歴をDBに登録するためのバッチ
- 1日1回ログからDBへ登録する
- 登録した結果は一応slackで通知する

# 関連するissue
- https://github.com/ienokado/debayashi-koreyashi/issues/28

# レビューポイント
バッチは1日1回深夜0時に昨日分の検索履歴ログをDBに登録する想定
検索履歴は常に登録されてしまうので、データが多くなった時にメモリ消費量激しそう（サーバ落ちちゃう）

# 留意事項
今まで検索されてきたログは本番では30日分しか保存しない設定にしているので、
今までのトータルは履歴として残せないため、
本番環境にデプロイしてからバッチを動かすようにする

本番環境にデプロイできたら過去分で残っているログファイルに関しては実行してDB登録予定

# 残課題
ランキング機能のPRは先にレビュー＆マージする
https://github.com/ienokado/debayashi-koreyashi/pull/123

# その他
