### PR TITLE
表示対象のcomedianGroupが存在するがそれに紐づくdebayashiが存在しない場合の対処

### DIFF
--- a/src/resources/views/debayashi/list-item.blade.php
+++ b/src/resources/views/debayashi/list-item.blade.php
@@ -1,16 +1,16 @@
 <div class="card-contents">
     <div class="card-debayashi-img">
         {{-- アートワーク --}}
-        @if ($comedianGroup->debayashi->spotifyInfos)
+        @if ($comedianGroup->debayashi && $comedianGroup->debayashi->spotifyInfos)
             <img class="card-debayashi-img-resize" src="{{ $comedianGroup->debayashi->spotifyInfos->image_url }}" alt="{{ $comedianGroup->debayashi->name }}">
-        @elseif ($comedianGroup->debayashi->appleMusicInfos)
+        @elseif ($comedianGroup->debayashi && $comedianGroup->debayashi->appleMusicInfos)
             <img class="card-debayashi-img-resize" src="{{ $comedianGroup->debayashi->appleMusicInfos->image_url}}" alt="{{ $comedianGroup->debayashi->name }}">
         @else
             <div class="card-debayashi-alt-img">
             </div>
         @endif
         {{-- メディアコントロール --}}
-        @if ($comedianGroup->debayashi->spotifyInfos || $comedianGroup->debayashi->appleMusicInfos)
+        @if ($comedianGroup->debayashi && ($comedianGroup->debayashi->spotifyInfos || $comedianGroup->debayashi->appleMusicInfos))
             <div class="card-preview-area">
                 <div class="card-preview-control" data-id="{{ $comedianGroup->debayashi->id}}">
                     <div class="card-icon-base-circle">
@@ -22,13 +22,13 @@
     </div>
     <div class="card-debayashi-info">
         <p class="card-item-comedian-group-name">{{ $comedianGroup->name }}</p>
-        <p class="card-item-debayashi-name">{{ $comedianGroup->debayashi->name }}</p>
-        <p class="card-item-artist-name">{{ $comedianGroup->debayashi->artist_name }}</p>
+        <p class="card-item-debayashi-name">{{ $comedianGroup->debayashi ? $comedianGroup->debayashi->name : ""}}</p>
+        <p class="card-item-artist-name">{{ $comedianGroup->debayashi ? $comedianGroup->debayashi->artist_name : ""}}</p>
     </div>
     {{-- メディアソース --}}
-    @if ($comedianGroup->debayashi->spotifyInfos && $comedianGroup->debayashi->spotifyInfos->preview_url)
+    @if ($comedianGroup->debayashi && ($comedianGroup->debayashi->spotifyInfos && $comedianGroup->debayashi->spotifyInfos->preview_url))
         <audio src="{{ $comedianGroup->debayashi->spotifyInfos->preview_url }}" data-id="{{ $comedianGroup->debayashi->id}}"></audio>
-    @elseif ($comedianGroup->debayashi->appleMusicInfos && $comedianGroup->debayashi->appleMusicInfos->preview_url)
+    @elseif ($comedianGroup->debayashi && ($comedianGroup->debayashi->appleMusicInfos && $comedianGroup->debayashi->appleMusicInfos->preview_url))
         <audio src="{{ $comedianGroup->debayashi->appleMusicInfos->preview_url }}" data-id="{{ $comedianGroup->debayashi->id}}"></audio>
     @endif
 </div>


### PR DESCRIPTION
# 目的
- 掲題の通り

# 関連するissue
- https://github.com/ienokado/debayashi-koreyashi/issues/125

# レビューポイント

# 留意事項
- cookieにcomedianGroupが保存されており、それに紐づくdebayashiが存在しないことが直接原因と思う
- comedianGroupが保存されていなければ、「検索履歴がありません」の表示となる
- 検索履歴画面でcookieに保存されたcomedianGroupに紐づくdebayashiが存在しないという事象(根本原因?)がどうして発生するかは不明(cookieに保存されている時点で出囃子がヒットしている前提)
- ランキング画面では、検索にヒットしないコンビもランキング対象となるため当事象が発生していた

# 残課題

# その他
