### PR TITLE
検索履歴をDB登録するタスクスケジュール

### DIFF
--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\SearchHistoryRegist;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -26,6 +27,9 @@ class Kernel extends ConsoleKernel
     {
         // $schedule->command('inspire')
         //          ->hourly();
+
+        // 前日分の検索履歴を1日1回DBに登録するコマンド実行
+        $schedule->command(SearchHistoryRegist::class)->daily();
     }
 
     /**


### PR DESCRIPTION
# 目的
- 1日1回検索履歴をDB登録するタスクをスケジュールする

# 関連するissue
なし

# レビューポイント

# 留意事項

# 残課題
`crontab -e` で
crontabに
`* * * * * cd /path-to-your-project && php artisan schedule:run >> /dev/null 2>&1`
コレは登録する必要がある


# その他
